### PR TITLE
update Makefile, delete ftprintf, builtin exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ LDFLAGS = -lreadline -lhistory -L$(shell brew --prefix readline)/lib
 # CFLAGS	+= -g -fsanitize=address
 LIBFT	= srcs/libft/libft.a
 LIBFTDIR	= srcs/libft/
-FTPRINTF	= srcs/printf/libftprintf.a
-FTPRINTFDIR	= srcs/printf/
 SRCDIR	= srcs/
 SRCNAME	= main.c \
 			utils/get_next_line.c \
@@ -28,21 +26,18 @@ SRCNAME	= main.c \
 SRCS	= $(addprefix $(SRCDIR), $(SRCNAME))
 OBJS	= $(SRCS:.c=.o)
 
-all:	$(NAME)
+all:		$(NAME)
 
 $(NAME):	$(OBJS)
-	make -C $(LIBFTDIR)
-	make -C $(FTPRINTFDIR)
-	$(CC) $(CFLAGS) $(RFLAGS) $(LDFLAGS) $(LIBFT) $(FTPRINTF) $^ -o $@
+			$(MAKE) -C $(LIBFTDIR)
+			$(CC) $(CFLAGS) $(RFLAGS) $(LDFLAGS) $(OBJS) $(LIBFT) -o $(NAME)
 
 clean:
-	make -C $(LIBFTDIR) clean
-	make -C $(FTPRINTFDIR) clean
+	$(MAKE) -C $(LIBFTDIR) clean
 	rm -f $(OBJS)
 
 fclean:	clean
-	make -C $(LIBFTDIR) fclean
-	make -C $(FTPRINTFDIR) fclean
+	$(MAKE) -C $(LIBFTDIR) fclean
 	rm -f $(NAME)
 
 re:	fclean	all

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -1,7 +1,7 @@
 #ifndef PARSER_H
 # define PARSER_H
 
-typedef struct s_str_list t_str_list;
+typedef struct s_str_list	t_str_list;
 
 typedef enum e_node_kind {
 	ND_EOF = -1,

--- a/srcs/builtin/cd.c
+++ b/srcs/builtin/cd.c
@@ -69,5 +69,5 @@ int	ft_cd(t_node *node)
 	chdir(path);
 	free(cwd);
 	free(path);
-	return (1);
+	exit (0);
 }

--- a/srcs/builtin/echo.c
+++ b/srcs/builtin/echo.c
@@ -34,11 +34,11 @@ int	ft_echo(t_node *node)
 		i++;
 	while (node->tokens[i])
 	{
-		ft_printf("%s", node->tokens[i]);
+		ft_putstr_fd(node->tokens[i], 1);
 		if (node->tokens[++i])
-			ft_printf(" ");
+			ft_putchar_fd(' ', 1);
 	}
 	if (new_line)
-		ft_printf("\n");
-	return (1);
+		ft_putchar_fd('\n', 1);
+	exit (0);
 }

--- a/srcs/builtin/env.c
+++ b/srcs/builtin/env.c
@@ -12,5 +12,5 @@ int	ft_env(t_node *node)
 		printf("%s\n", environ[i]);
 		i++;
 	}
-	return (1);
+	exit (0);
 }

--- a/srcs/builtin/exit.c
+++ b/srcs/builtin/exit.c
@@ -3,17 +3,18 @@
 #include "parser.h"
 #include <limits.h>
 
+
 int	is_overflow(long long n, int sign, char *str)
 {
 	int is_next_num;
 
     is_next_num = ft_isdigit(str[1]);
     if (is_next_num == 0)
-        return (0);
+		return (0);
     n *= sign;
-	if (is_next_num && (n > LONG_MAX / 10 || (n == LONG_MAX / 10 && str[1] > '7')))
+	if (n > LONG_MAX / 10 || (n == LONG_MAX / 10 && str[1] > '7'))
         return (1);
-    else if (is_next_num && (n < LONG_MIN / 10 || (n == LONG_MIN / 10 && str[1] > '8')))
+    else if (n < LONG_MIN / 10 || (n == LONG_MIN / 10 && str[1] > '8'))
         return (1);
 	return (0);
 }
@@ -36,7 +37,6 @@ int	is_digit_without_overflow(char *str)
 		str++;
 	while (*str && ft_isdigit(*str))
 	{
-		printf("in loop\n");
         if (res)
 			res *= 10;
 		res += *str - '0';
@@ -71,13 +71,16 @@ void	free_node(t_node *node)
 
 void	ft_exit(t_node *node)
 {
-	int	exit_code;
+	unsigned char	exit_code;
 	
 	exit_code = 0;
 	if (node->tokens[1])
 	{
 		if (is_digit_without_overflow(node->tokens[1]))
+		{
 			exit_code = ft_atoi(node->tokens[1]);
+		}
+			
 		else
 		{
 			error_numeric_argument(node->tokens[1]);

--- a/srcs/builtin/export.c
+++ b/srcs/builtin/export.c
@@ -51,5 +51,5 @@ int	ft_export(t_node *node)
 		memmove(environ + envlen + 1, environ + envlen, 1 * sizeof(char *));
 		environ[envlen] = ft_setenv(node->tokens[1]);
 	}
-	return (1);
+	exit (0);
 }

--- a/srcs/builtin/pwd.c
+++ b/srcs/builtin/pwd.c
@@ -29,7 +29,7 @@ int	ft_pwd(t_node *node)
 	cwd = ft_getcwd();
 	//OLDPWD=PWD
 	//PWD=cwd
-	ft_printf("%s\n", cwd);
+	ft_putendl_fd(cwd, 1);
 	free(cwd);
-	return (1);
+	exit (0);
 }

--- a/srcs/builtin/unset.c
+++ b/srcs/builtin/unset.c
@@ -25,5 +25,5 @@ int	ft_unset(t_node *node)
 		memmove(environ + i, environ + i + 1,
 			(envlen - i + 1) * sizeof(char *));
 	}
-	return (1);
+	exit (0);
 }

--- a/srcs/libft/Makefile
+++ b/srcs/libft/Makefile
@@ -10,29 +10,25 @@
 #                                                                              #
 # **************************************************************************** #
 
-NAME		= libft.a
-SRCS		= ft_strdup.c ft_strjoin.c ft_atoi.c ft_strlcat.c ft_bzero.c ft_strlcpy.c ft_calloc.c ft_memccpy.c ft_strlen.c ft_isalnum.c ft_memchr.c ft_strmapi.c ft_isalpha.c ft_memcmp.c ft_strcmp.c ft_strncmp.c ft_isascii.c ft_memcpy.c ft_isspace.c ft_isdigit.c ft_memmove.c ft_strnstr.c ft_isprint.c ft_memset.c ft_strrchr.c ft_itoa.c ft_putchar_fd.c ft_strtrim.c ft_putendl_fd.c ft_substr.c ft_putnbr_fd.c ft_tolower.c ft_putstr_fd.c ft_toupper.c ft_split.c ft_strchr.c
-OBJS		= $(SRCS:.c=.o)
-BONUS_SRCS	= ft_lstiter.c ft_lstdelone.c ft_lstadd_front.c ft_lstlast.c ft_lstmap.c ft_lstnew.c ft_lstsize.c ft_lstadd_back.c ft_lstclear.c
-BONUS_OBJS	= $(BONUS_SRCS:.c=.o)
-CC			= gcc
-CFLAG		= -Wall -Wextra -Werror -c -I libft.h
+NAME	=	libft.a
+CC		=	gcc
+CFLAGS	=	-Wall	-Wextra	-Werror
+RM		=	rm -f
+INCDIR	=	./libft
+SRCDIR	=	./
+SRCNAME	=	ft_strdup.c ft_strjoin.c ft_atoi.c ft_strlcat.c ft_bzero.c ft_strlcpy.c ft_calloc.c ft_memccpy.c ft_strlen.c ft_isalnum.c ft_memchr.c ft_strmapi.c ft_isalpha.c ft_memcmp.c ft_strcmp.c ft_strncmp.c ft_isascii.c ft_memcpy.c ft_isspace.c ft_isdigit.c ft_memmove.c ft_strnstr.c ft_isprint.c ft_memset.c ft_strrchr.c ft_itoa.c ft_putchar_fd.c ft_strtrim.c ft_putendl_fd.c ft_substr.c ft_putnbr_fd.c ft_tolower.c ft_putstr_fd.c ft_toupper.c ft_split.c ft_strchr.c \
+			ft_lstiter.c ft_lstdelone.c ft_lstadd_front.c ft_lstlast.c ft_lstmap.c ft_lstnew.c ft_lstsize.c ft_lstadd_back.c ft_lstclear.c
 
-all:		$(NAME) bonus
-
-clean:
-	rm -rf $(OBJS) $(BONUS_OBJS)
-
-fclean:		clean
-	rm -rf $(NAME)
-
-re:			fclean all
-
-$(NAME):	$(OBJS)
-	ar -rc $@ $^
-
-bonus:		$(OBJS) $(BONUS_OBJS)
-	ar -rc $(NAME) $^
-
+SRCS	=	$(addprefix $(SRCDIR), $(SRCNAME))
+OBJS	=	$(SRCS:.c=.o)
 .c.o:
-	$(CC) $(CFLAG) $^
+			$(CC) $(CFLAGS)	-I $(INCDIR) -c $< -o $(<:.c=.o)
+$(NAME):	$(OBJS)
+			ar	rc	$(NAME)	$(OBJS)
+all:		$(NAME)
+clean:
+			$(RM) $(OBJS) 
+fclean:		clean
+			$(RM) $(NAME)
+re:			fclean all
+.PHONY:	all clean fclean re

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -86,23 +86,23 @@ int	main(void)
 	t_str_list	*tmp;
 	t_node		*node;
 
-	ft_printf("minishell > ");
+	ft_putstr_fd("minishell > ", 1);
 	while (minishell_get_next_line(0, &line) == 1)
 	{
-		ft_printf("line[%p]:%s\n", line, line);
+		printf("line[%p]:%s\n", line, line);
 		splited_lines = shell_split(line);
 		splited_lines = var_expansion(splited_lines);
 		tmp = splited_lines;
 		while (tmp)
 		{
-			ft_printf("[%p][%p]%s\n", tmp, tmp->s, tmp->s);
+			printf("[%p][%p]%s\n", tmp, tmp->s, tmp->s);
 			tmp = tmp->next;
 		}
 		tmp = splited_lines;
 		node = semicolon_node_creator(&splited_lines);
 		free(line);
 		if (exec_command(node) == 1)
-			break;
+			break ;
 		if (node->cm_kind == EXIT) /* pipeありの場合はexitしない */
 		{
 			free_node(node);
@@ -112,7 +112,7 @@ int	main(void)
 		free_list(tmp);
 		free_node(node);
 		free(node);
-		ft_printf("minishell > ");
+		ft_putstr_fd("minishell > ", 1);
 	}
 	free_list(tmp);
 	free_node(node);

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -249,42 +249,43 @@ char	**define_args_cmpath(t_str_list **list, t_node *node)
 		i++;
 	}
 	args[i] = NULL;
+	print_tokens(args);
 	printf("end define_args_cmpath!\n");
 	return (args);
 }
 
-char	**define_args(t_str_list **list, t_node *node)
-{
-	char	**args;
-	int		i;
-	t_str_list	*head;
+// char	**define_args(t_str_list **list, t_node *node)
+// {
+// 	char	**args;
+// 	int		i;
+// 	t_str_list	*head;
 
-	printf("enter define_args!\n");
-	head = *list;
-	i = 0;
-	while (*list && *(*list)->s == '-' && *((*list)->next->s) != 0)
-	{
-		i++;
-		*list = (*list)->next;
-	}
-	args = ft_calloc(i + 3, sizeof(char **));
-	printf("size of arg: %d\n", i + 2);
-	args[0] = node->cm_content;
-	*list = head;
-	i = 1;
-	(*list)->s = remove_quotations((*list)->s);
-	while (*list && *(*list)->s == '-' && *((*list)->next->s) != 0)
-	{
-		args[i] = set_args_option((*list)->s);
-		*list = (*list)->next;
-		(*list)->s = remove_quotations((*list)->s);
-		i++;
-	}
-	args[i] = set_args_content(list);
-	args[++i] = NULL;
-	printf("end define_args!\n");
-	return (args);
-}
+// 	printf("enter define_args!\n");
+// 	head = *list;
+// 	i = 0;
+// 	while (*list && *(*list)->s == '-' && *((*list)->next->s) != 0)
+// 	{
+// 		i++;
+// 		*list = (*list)->next;
+// 	}
+// 	args = ft_calloc(i + 3, sizeof(char **));
+// 	printf("size of arg: %d\n", i + 2);
+// 	args[0] = node->cm_content;
+// 	*list = head;
+// 	i = 1;
+// 	(*list)->s = remove_quotations((*list)->s);
+// 	while (*list && *(*list)->s == '-' && *((*list)->next->s) != 0)
+// 	{
+// 		args[i] = set_args_option((*list)->s);
+// 		*list = (*list)->next;
+// 		(*list)->s = remove_quotations((*list)->s);
+// 		i++;
+// 	}
+// 	args[i] = set_args_content(list);
+// 	args[++i] = NULL;
+// 	printf("end define_args!\n");
+// 	return (args);
+// }
 
 void	set_redirect_path(t_str_list **list, t_node *node)
 {
@@ -371,10 +372,11 @@ t_node *command_node_creator(t_str_list **token_list)
 	if ((*token_list)->next)
 	{
 		(*token_list) = (*token_list)->next;
-		if (node->cm_kind == OTHER)
-			node->tokens = define_args_cmpath(token_list, node);
-		else
-			node->tokens = define_args(token_list, node);
+		// if (node->cm_kind == OTHER)
+		// 	node->tokens = define_args_cmpath(token_list, node);
+		// else
+		// 	node->tokens = define_args(token_list, node);
+		node->tokens = define_args_cmpath(token_list, node);
 		if (*token_list)
 		{
 			(*token_list)->s = remove_quotations((*token_list)->s);

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -3,7 +3,7 @@
 
 void	error_numeric_argument(char *str)
 {
-    ft_putstr_fd("bash: exit: ", 2);
+    ft_putstr_fd("minishell: exit: ", 2);
     ft_putstr_fd(str, 2);
     ft_putendl_fd(": numeric argument required", 2);
 }


### PR DESCRIPTION
- Makefile修正とftprintfの削除
Makefileのリリンクしない問題解決のため、libftのMakefileを修正、ftprintfは使えないのでMakefile上とコード上から削除（ディレクトリ自体は残ってます）し、大元のMakefileもちょっと直してみた結果、libftのリリンクは治ったのですが、大元については最後まで解決できていないみたいです。。

- ftprintfの削除
ftprintfは今回は使えないと思うので、ft_putstr_fdなどに変更し、Makefileからftprintfの記述を消しました。

- builtinコマンドの子プロセスをすべてexit関数で抜けるよう処理
builtinのexit以外のコマンドの子プロセスについても、きちんと子プロセスで終わらせるように修正し、リダイレクトにも対応できるようにしました...!

- exitコマンドの終了コードの修正
exitコマンドの引数番号を仕様に合わせて調整しました。（LONG_MIN ~ LONG_MAXまでを数字と認識し、それを0 ~ 255に直して終了コードとする）